### PR TITLE
 #157768910 Add admin_dashboard page

### DIFF
--- a/UI/admin/admin_dashboard.html
+++ b/UI/admin/admin_dashboard.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="X-UA-Compatible" content="ie=edge">
+    <title>Maintenance Tracker</title>
+    <link rel="stylesheet" href="../css/style.css">
+</head>
+<body>
+    <div class="header">
+        <h1>Welcome to Maintenance Tracker</h1>
+    </div>
+    <div class="left_panel_dashboard">
+        <img src="../images/avatar.png" alt="Avatar" style="width:200px">
+        <button type="submit" class="button">View Requests</button>
+        <button type="submit" class="button">View Approved</button>
+        <button type="submit" class="button">View Resolved</button>
+        <button type="submit" class="button">View Rejected</button>
+        <button type="submit" class="button">Edit Profile</button>
+        <button type="submit" class="button">Logout</button>
+    </div>
+    <div class="footer">
+        <h3>Copyright &copy; 2018</h3>
+    </div>
+</body>
+</html>


### PR DESCRIPTION
### What does this PR do?
- Adds an admin dashboard page.

### Description of task completed?
- Create a page where an admin can manage the application from.

### How should this be manually tested?
- Clone or download the project
$ git clone https://github.com/paulkitonyi/Maintenance-Tracker/tree/ft-admin-dashboard-page-#157768910
- Navigate to UI directory then admin, and click the admin_dashboard.html file to view the admin dashboard page on a browser.

### Any background context you want to provide?
Created using: HTML5 and CSS.Not yet Responsive.

### What are the relevant pivotal tracker stories?
[##157768910](https://www.pivotaltracker.com/n/projects/2173306/stories/157768910)

### Screenshots (if appropriate)
![screenshot from 2018-05-26 16-54-32](https://user-images.githubusercontent.com/21083657/40576842-904602cc-6105-11e8-82a9-c530224242c2.png)
