### PR TITLE
 #157769265 Add a view request page for admin

### DIFF
--- a/UI/admin/admin_view_requests.html
+++ b/UI/admin/admin_view_requests.html
@@ -1,0 +1,67 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="X-UA-Compatible" content="ie=edge">
+    <title>Maintenance Tracker</title>
+    <link rel="stylesheet" href="../css/style.css">
+</head>
+<body>
+    <div class="header">
+        <h1>Welcome to Maintenance Tracker</h1>
+    </div>
+    <div class="left_panel_dashboard">
+        <img src="../images/avatar.png" alt="Avatar" style="width:200px">
+        <button type="submit" class="button">View Requests</button>
+        <button type="submit" class="button">View Approved</button>
+        <button type="submit" class="button">View Resolved</button>
+        <button type="submit" class="button">View Rejected</button>
+        <button type="submit" class="button">Edit Profile</button>
+        <button type="submit" class="button">Logout</button>
+    </div>
+    <div>
+        <table align="right">
+            <tr>
+                <th>#</th>
+                <th>Requester</th>
+                <th>Department</th>
+                <th>Device Type</th>
+                <th>Request Type</th>
+                <th>Action</th>
+                <th>Status</th>
+            </tr>
+            <tr>
+                <td>1</td>
+                <td>Paul</td>
+                <td>Accounts</td>
+                <td>Laptop</td>
+                <td>Maintenance</td>
+                <td>Approved</td>
+                <td>Pending</td>
+            </tr>
+            <tr>
+                <td>2</td>
+                <td>Peter</td>
+                <td>Accounts</td>
+                <td>Printer</td>
+                <td>Maintenance</td>
+                <td>Rejected</td>
+                <td>Pending</td>
+            </tr>
+            <tr>
+                <td>3</td>
+                <td>Jane</td>
+                <td>Public Relations</td>
+                <td>landline</td>
+                <td>Repair</td>
+                <td>Approved</td>
+                <td>Resolved</td>
+            </tr>
+        </table>
+    </div>
+    <div class="footer">
+        <h3>Copyright &copy; 2018</h3>
+    </div>
+</body>
+</html>


### PR DESCRIPTION
### What does this PR do?
- Adds an admin view requests page.

### Description of task completed?
- Create a page where an admin can view all the requests made.

### How should this be manually tested?
- Clone or download the project
$ git clone https://github.com/paulkitonyi/Maintenance-Tracker/tree/ft-admin-view-requests-#157769265

### Navigate to UI directory then admin, and click the admin_view_requests.html file to view the admin view page on a browser.

### Any background context you want to provide?
- Created using: HTML5 and CSS.Not yet Responsive.

### What are the relevant pivotal tracker stories?
[#157769265](https://www.pivotaltracker.com/n/projects/2173306/stories/157769265)

Screenshots (if appropriate)
![screenshot from 2018-05-26 17-42-13](https://user-images.githubusercontent.com/21083657/40577478-03829152-610f-11e8-91b7-719311dc5759.png)
